### PR TITLE
Explainer for Sec-CH-UA-Form-Factor

### DIFF
--- a/sec-ch-ua-form-factor.md
+++ b/sec-ch-ua-form-factor.md
@@ -38,25 +38,9 @@ using the
 [`Critical-CH`](https://datatracker.ietf.org/doc/html/draft-davidben-http-client-hint-reliability#name-the-critical-ch-response-he)
 response header.
 
-## Dimensions
-
-The information required by a site falls into three categories:
-
- * Output - how does the user-agent present information to the user?
- * Interaction - how does the user interact with the user-agent?
- * Attention - what level of attention can be expected from the user?
-
-Output may distinguish XR from screen-based presentations, or identify
-limited-capability displays such as eInk.
-
-Interaction may differentiate keyboard/mouse input from gestural or touch input.
-
-Attention may indicate that a user's attention is focused elsewhere, such as in
-an automotive setting.
-
 ## Format
 
-The format of the header and its allowed values remain to be determined.
+The content and format of the header and its allowed values remain to be determined.
 
 # References
 

--- a/sec-ch-ua-form-factor.md
+++ b/sec-ch-ua-form-factor.md
@@ -1,0 +1,64 @@
+# Problem
+
+Sites often differ dramatically depending on the device where they are loaded.
+This has long been the case with "mobile" and "desktop" versions of sites, but
+novel user-agent form-factors such as cars, televisions, and virtual reality
+introduce new opportunities for site customization.
+
+Historically, sites have derived the form-factor of a user-agent through some
+combination of the user-agent string, the `Sec-CH-UA-Mobile` header, and screen
+size. The signal from these sources is unclear, and incorrect derivations lead
+to poor user experience, such as a desktop site designed for mouse and keyboard
+interaction appearing on a television.
+
+In some cases, it is important to know the form-factor of a user-agent before
+the first request is served. For example, some form-factors require large
+client-side libraries which should not be transmitted when not required.
+
+Providing a detailed description of the user-agent's form factor could provide
+signficant metadata for undesirable fingerprinting, especially for early-adopter
+users of new form-factors. We must avoid providing such metadata except where
+desired by the user.
+
+# Proposal
+
+[Client Hints](https://github.com/WICG/ua-client-hints) support providing sites
+with clear signals about client characteristics in a privacy-preserving fashion.
+We propose a new header,
+[`Sec-CH-UA-Form-Factor`](https://wicg.github.io/ua-client-hints/#sec-ch-ua-form-factor),
+to include information about the device's form factor.
+
+This hint is considered "high-entropy" and thus only available to sites that
+request it. In most situations, the hint value can be retrieved using
+[`Accept-CH`](https://www.rfc-editor.org/rfc/rfc8942#name-the-accept-ch-response-head)
+or by consulting the
+[`userAgentData.getHighEntropyData()`](https://wicg.github.io/ua-client-hints/#getHighEntropyValues)
+API. Where necessary, sites can receive the value on the first request
+using the
+[`Critical-CH`](https://datatracker.ietf.org/doc/html/draft-davidben-http-client-hint-reliability#name-the-critical-ch-response-he)
+response header.
+
+## Dimensions
+
+The information required by a site falls into three categories:
+
+ * Output - how does the user-agent present information to the user?
+ * Interaction - how does the user interact with the user-agent?
+ * Attention - what level of attention can be expected from the user?
+
+Output may distinguish XR from screen-based presentations, or identify
+limited-capability displays such as eInk.
+
+Interaction may differentiate keyboard/mouse input from gestural or touch input.
+
+Attention may indicate that a user's attention is focused elsewhere, such as in
+an automotive setting.
+
+## Format
+
+The format of the header and its allowed values remain to be determined.
+
+# References
+
+* https://github.com/WICG/ua-client-hints
+* https://github.com/WICG/ua-client-hints/issues/344


### PR DESCRIPTION
This is a little late, as this header [exists in the spec already](https://wicg.github.io/ua-client-hints/#sec-ch-ua-form-factor), but an explainer will help provide a centralized place for the "why" of what we're doing.
